### PR TITLE
Resolve #956, #957, #958, #960, #962, #964, #965, #966, #967

### DIFF
--- a/src/accounts/BitcoinAccount.js
+++ b/src/accounts/BitcoinAccount.js
@@ -67,6 +67,11 @@ export default class BitcoinAccount implements IAccount<AccountData> {
     this.accountData = _accountData
   }
 
+  clearPrivateKey = () => {
+    this.accountData.privateKey = null
+    this.accountData.hdWalletVariables.xpriv = null
+  }
+
   getAccountData = (): AccountData => {
     return this.accountData
   }
@@ -80,8 +85,7 @@ export default class BitcoinAccount implements IAccount<AccountData> {
       this.accountData.hdWalletVariables.xpriv,
       password
     )
-    this.accountData.privateKey = null
-    this.accountData.hdWalletVariables.xpriv = null
+    this.clearPrivateKey()
   }
 
   decryptAccount = async (password: string) => {
@@ -312,9 +316,11 @@ export default class BitcoinAccount implements IAccount<AccountData> {
       const addressPath = `${BASE_BTC_PATH}/${accountIndex}'/${change}/${currentIdx}`
       const address = this._getDerivedAddress(xpub, change, currentIdx)
 
-      const response = (await axios.get(
-        `${url.LEDGER_API_URL}/addresses/${address}/transactions?noToken=true&truncated=true`
-      )).data
+      const response = (
+        await axios.get(
+          `${url.LEDGER_API_URL}/addresses/${address}/transactions?noToken=true&truncated=true`
+        )
+      ).data
 
       if (response.txs.length === 0) {
         gap++

--- a/src/accounts/EthereumAccount.js
+++ b/src/accounts/EthereumAccount.js
@@ -40,6 +40,10 @@ export default class EthereumAccount implements IAccount<AccountData> {
     this.accountData = _accountData
   }
 
+  clearPrivateKey = () => {
+    this.accountData.privateKey = null
+  }
+
   getAccountData = (): AccountData => {
     return this.accountData
   }
@@ -53,7 +57,7 @@ export default class EthereumAccount implements IAccount<AccountData> {
       password
     )
     // errase private key
-    this.accountData.privateKey = null
+    this.clearPrivateKey()
   }
 
   decryptAccount = async (password: string) => {

--- a/src/accounts/EthereumAccount.js
+++ b/src/accounts/EthereumAccount.js
@@ -63,7 +63,6 @@ export default class EthereumAccount implements IAccount<AccountData> {
     let privateKey = await utils.decryptMessage(this.accountData.encryptedPrivateKey, password)
     if (!privateKey) throw new Error('Incorrect password')
     this.accountData.privateKey = privateKey
-    this.accountData.encryptedPrivateKey = undefined
 
     const _web3 = new Web3(new Web3.providers.HttpProvider(url.INFURA_API_URL))
     this.accountData.address = _web3.eth.accounts.privateKeyToAccount(privateKey).address
@@ -79,10 +78,9 @@ export default class EthereumAccount implements IAccount<AccountData> {
 
     // set token balance
     if (['dai'].includes(cryptoType)) {
-      this.accountData.balance = (await ERC20.getBalance(
-        this.accountData.address,
-        cryptoType
-      )).toString()
+      this.accountData.balance = (
+        await ERC20.getBalance(this.accountData.address, cryptoType)
+      ).toString()
     } else {
       // copy eth balance
       this.accountData.balance = this.accountData.ethBalance

--- a/src/actions/accountActions.js
+++ b/src/actions/accountActions.js
@@ -237,6 +237,19 @@ async function _removeCryptoAccount (accountData: AccountData): Promise<Array<Ac
   return cryptoAccounts
 }
 
+function _clearAccountPrivateKey (accountData: AccountData) {
+  let _account = createAccount(accountData)
+  _account.clearPrivateKey()
+  return _account.getAccountData()
+}
+
+function clearAccountPrivateKey (accountData: AccountData) {
+  return {
+    type: 'CLEAR_ACCOUNT_PRIVATE_KEY',
+    payload: _clearAccountPrivateKey(accountData)
+  }
+}
+
 export {
   syncWithNetwork,
   getTxFee,
@@ -245,5 +258,6 @@ export {
   markAccountDirty,
   getCryptoAccounts,
   addCryptoAccount,
-  removeCryptoAccount
+  removeCryptoAccount,
+  clearAccountPrivateKey
 }

--- a/src/actions/transferActions.js
+++ b/src/actions/transferActions.js
@@ -16,6 +16,7 @@ import type { StandardTokenUnit, BasicTokenUnit, Address } from '../types/token.
 import type { AccountData } from '../types/account.flow.js'
 import { createWallet } from '../wallets/WalletFactory'
 import { createAccount } from '../accounts/AccountFactory'
+import { clearAccountPrivateKey } from './accountActions'
 
 const transferStates = {
   SEND_PENDING: 'SEND_PENDING',
@@ -61,7 +62,7 @@ function directTransfer (txRequest: {
     return dispatch({
       type: 'DIRECT_TRANSFER',
       payload: _directTransfer(txRequest)
-    })
+    }).then(() => dispatch(clearAccountPrivateKey(txRequest.fromAccount)))
   }
 }
 
@@ -565,9 +566,11 @@ function submitTx (txRequest: {
   sendMessage: ?string,
   txFee: TxFee
 }) {
-  return {
-    type: 'SUBMIT_TX',
-    payload: _submitTx(txRequest)
+  return (dispatch: Function, getState: Function) => {
+    return dispatch({
+      type: 'SUBMIT_TX',
+      payload: _submitTx(txRequest)
+    }).then(() => dispatch(clearAccountPrivateKey(txRequest.fromAccount)))
   }
 }
 

--- a/src/components/AccountDropdownComponent.jsx
+++ b/src/components/AccountDropdownComponent.jsx
@@ -26,10 +26,28 @@ type Props = {
   error: Object,
   onChange: Function,
   addAccount: Function,
-  toCurrencyAmount: Function
+  toCurrencyAmount: Function,
+  inputLabel: string
 }
 
-class AccountDropdownComponent extends Component<Props> {
+type State = {
+  inputLabelWidth: number
+}
+
+class AccountDropdownComponent extends Component<Props, State> {
+  inputLabelRef: any
+
+  constructor (props) {
+    super(props)
+    this.state = {
+      inputLabelWidth: 0
+    }
+    this.inputLabelRef = React.createRef()
+  }
+  componentDidMount () {
+    this.setState({ inputLabelWidth: this.inputLabelRef.current.offsetWidth })
+  }
+
   renderAccountItem = item => {
     const { toCurrencyAmount } = this.props
 
@@ -88,7 +106,16 @@ class AccountDropdownComponent extends Component<Props> {
   }
 
   render () {
-    const { classes, account, cryptoAccounts, onChange, addAccount, pending, error } = this.props
+    const {
+      classes,
+      account,
+      cryptoAccounts,
+      onChange,
+      addAccount,
+      pending,
+      error,
+      inputLabel
+    } = this.props
     let skeletonCryptoAccounts = []
     if (pending) {
       skeletonCryptoAccounts = [
@@ -101,7 +128,9 @@ class AccountDropdownComponent extends Component<Props> {
     return (
       <Grid container direction='column'>
         <FormControl variant='outlined'>
-          <InputLabel htmlFor='destination-helper'>Select Account</InputLabel>
+          <InputLabel ref={this.inputLabelRef} htmlFor='destination-helper'>
+            {inputLabel}
+          </InputLabel>
           <Select
             renderValue={value => {
               return (
@@ -120,7 +149,7 @@ class AccountDropdownComponent extends Component<Props> {
             }}
             value={account || ''}
             onChange={onChange}
-            input={<OutlinedInput labelWidth={125} name='Select Account' />}
+            input={<OutlinedInput labelWidth={this.state.inputLabelWidth} name='Select Account' />}
             error={!!error}
             id='accountSelection'
           >

--- a/src/components/AccountsManagementComponent.jsx
+++ b/src/components/AccountsManagementComponent.jsx
@@ -6,6 +6,7 @@ import Avatar from '@material-ui/core/Avatar'
 import { btnTexts } from '../styles/typography'
 import { uiColors } from '../styles/color'
 import CloseIcon from '@material-ui/icons/Close'
+import CircularProgress from '@material-ui/core/CircularProgress'
 import Dialog from '@material-ui/core/Dialog'
 import DialogContent from '@material-ui/core/DialogContent'
 import DialogTitle from '@material-ui/core/DialogTitle'
@@ -107,6 +108,8 @@ class AccountsManagementComponent extends Component {
           <Typography variant='body1' align='center'>
             It seems you don't have any accounts saved
           </Typography>
+        ) : actionsPending.getCryptoAccounts ? (
+          <CircularProgress style={{ marginTop: '10px', alignSelf: 'center' }} />
         ) : (
           <Table>
             <TableHead>

--- a/src/components/DirectTransferFormComponent.jsx
+++ b/src/components/DirectTransferFormComponent.jsx
@@ -1,0 +1,104 @@
+import React, { Component } from 'react'
+import { withStyles } from '@material-ui/core/styles'
+
+import clsx from 'clsx'
+import Grid from '@material-ui/core/Grid'
+import Icon from '@material-ui/core/Icon'
+import InputAdornment from '@material-ui/core/InputAdornment'
+import TextField from '@material-ui/core/TextField'
+import AccountDropdown from '../containers/AccountDropdownContainer'
+import { getCryptoSymbol } from '../tokens'
+
+class DirectTransferFormComponent extends Component {
+  render () {
+    const {
+      classes,
+      currency,
+      handleTransferFormChange,
+      accountSelection,
+      transferForm,
+      balanceCurrencyAmount
+    } = this.props
+    const { formError, transferAmount, transferCurrencyAmount, destination } = transferForm
+    return (
+      <Grid container direction='column' spacing={2}>
+        <Grid item>
+          <TextField
+            fullWidth
+            id='sender'
+            label='From'
+            margin='normal'
+            variant='outlined'
+            value={'Chainsfr Wallet'}
+            disabled
+          />
+        </Grid>
+        <Grid item>
+          <AccountDropdown
+            onChange={handleTransferFormChange('destination')}
+            filterCriteria={accountData => accountData.walletType !== 'drive'}
+            accountId={destination}
+            inputLabel='To'
+          />
+        </Grid>
+        <Grid item>
+          <Grid container direction='row' justify='center' alignItems='center' spacing={2}>
+            <Grid item xs>
+              <TextField
+                margin='normal'
+                fullWidth
+                id='currencyAmount'
+                variant='outlined'
+                label='Fiat'
+                error={!!formError.transferCurrencyAmount}
+                helperText={formError.transferCurrencyAmount || `Balance: ${balanceCurrencyAmount}`}
+                type='number'
+                disabled={!accountSelection}
+                onChange={handleTransferFormChange('transferCurrencyAmount')}
+                value={transferCurrencyAmount}
+                InputProps={{
+                  startAdornment: <InputAdornment position='start'>{currency}</InputAdornment>
+                }}
+              />
+            </Grid>
+            <Grid item align='center'>
+              <Icon className={clsx(classes.icon, 'fa fa-exchange-alt')} />
+            </Grid>
+            <Grid item xs>
+              <TextField
+                margin='normal'
+                fullWidth
+                id='cryptoAmount'
+                variant='outlined'
+                label='Amount (Cryptocurrency)'
+                error={!!formError.transferAmount}
+                type='number'
+                helperText={
+                  formError.transferAmount ||
+                  (accountSelection
+                    ? `Balance: ${accountSelection.balanceInStandardUnit} ${getCryptoSymbol(
+                        accountSelection.cryptoType
+                      )}`
+                    : 'Balance: 0')
+                }
+                disabled={!accountSelection}
+                onChange={handleTransferFormChange('transferAmount')}
+                value={transferAmount}
+                InputProps={{
+                  startAdornment: (
+                    <InputAdornment position='start'>
+                      {getCryptoSymbol(accountSelection && accountSelection.cryptoType)}
+                    </InputAdornment>
+                  )
+                }}
+              />
+            </Grid>
+          </Grid>
+        </Grid>
+      </Grid>
+    )
+  }
+}
+
+const styles = theme => ({})
+export default withStyles(styles)(DirectTransferFormComponent)

--- a/src/components/EmailTransferFormComponent.jsx
+++ b/src/components/EmailTransferFormComponent.jsx
@@ -37,7 +37,7 @@ type Props = {
   accountSelection: Object
 }
 
-class TransferFormComponent extends Component<Props> {
+class EmailTransferFormComponent extends Component<Props> {
   render () {
     const {
       classes,
@@ -187,7 +187,7 @@ class TransferFormComponent extends Component<Props> {
                 }
                 disabled={!accountSelection}
                 onChange={handleTransferFormChange('transferAmount')}
-                value={transferAmount || 0}
+                value={transferAmount}
                 InputProps={{
                   startAdornment: (
                     <InputAdornment position='start'>
@@ -323,4 +323,4 @@ const styles = theme => ({
   }
 })
 
-export default withStyles(styles)(TransferFormComponent)
+export default withStyles(styles)(EmailTransferFormComponent)

--- a/src/components/NavBarComponent.jsx
+++ b/src/components/NavBarComponent.jsx
@@ -15,6 +15,7 @@ import Avatar from '@material-ui/core/Avatar'
 import Divider from '@material-ui/core/Divider'
 import { uiColors, fontColors } from '../styles/color'
 import ChainsfrLogo from '../images/chainsfr_logo.svg'
+import Stepper from './Stepper'
 
 class NavBarComponent extends Component {
   state = {
@@ -33,9 +34,62 @@ class NavBarComponent extends Component {
     this.setState({ anchorEl: null })
   }
 
-  render () {
-    const { classes, backToHome, profile, disabled } = this.props
+  renderProfileButton = () => {
+    const { classes, profile, disabled } = this.props
     const { anchorEl } = this.state
+    return (
+      <>
+        <Button
+          aria-owns={anchorEl ? 'simple-menu' : undefined}
+          aria-haspopup='true'
+          onClick={this.handleToggle}
+          id='avatarBtn'
+          style={{ textTransform: 'none' }}
+          disabled={disabled}
+        >
+          {profile && profile.profileObj && profile.profileObj.imageUrl ? (
+            <Avatar alt='' src={profile.profileObj.imageUrl} className={classes.avatar} />
+          ) : (
+            <AccountCircle className={classes.userIcon} id='accountCircle' />
+          )}
+          <Typography variant='body2'>{profile.profileObj.name}</Typography>
+        </Button>
+        <Menu
+          id='simple-menu'
+          anchorEl={anchorEl}
+          getContentAnchorEl={null}
+          open={Boolean(anchorEl)}
+          onClose={this.handleClose()}
+          anchorOrigin={{
+            vertical: 'bottom',
+            horizontal: 'right'
+          }}
+          transformOrigin={{
+            vertical: 'top',
+            horizontal: 'right'
+          }}
+        >
+          <Container className={classes.menuContainer}>
+            {profile && profile.profileObj && profile.profileObj.imageUrl ? (
+              <Avatar alt='' src={profile.profileObj.imageUrl} className={classes.avatar} />
+            ) : (
+              <AccountCircle className={classes.userIcon} id='accountCircle' />
+            )}
+            <Typography className={classes.menuItemUserName}>{profile.profileObj.name}</Typography>
+            <Typography className={classes.menuItemEmail}>{profile.profileObj.email}</Typography>
+            <Divider />
+            <Button onClick={this.handleClose('logout')} id='logout' className={classes.logoutBtn}>
+              <ExitIcon className={classes.logoutIcon} id='exitIcon' />
+              <Typography>Logout</Typography>
+            </Button>
+          </Container>
+        </Menu>
+      </>
+    )
+  }
+
+  render () {
+    const { classes, backToHome, profile, disabled, location, step } = this.props
 
     return (
       <AppBar position='static' color='primary' className={classes.appBar}>
@@ -57,95 +111,50 @@ class NavBarComponent extends Component {
                     <img className={classes.chainsfrLogo} src={ChainsfrLogo} alt='Chainsfr Logo' />
                   </Button>
                 </Grid>
-                {profile.isAuthenticated && (
-                  <Grid item>
-                    <Grid container alignItems='center'>
-                      <Grid item xs={12} sm='auto'>
-                        <Button className={classes.NaviBtn} component={Link} to={path.home}>
-                          Home
-                        </Button>
+                {profile.isAuthenticated &&
+                  ([path.receive, path.transfer].includes(location.pathname) ? (
+                    <>
+                      <Grid item xs style={{ maxWidth: '480px' }}>
+                        {location.pathname === path.transfer && (
+                          <Stepper actionType='transfer' step={step} />
+                        )}
+                        {location.pathname === path.receive && (
+                          <Stepper actionType='receive' step={step} />
+                        )}
                       </Grid>
                       <Grid item xs={12} sm='auto'>
-                        <Button className={classes.NaviBtn} component={Link} to={path.recipients}>
-                          Recipients
-                        </Button>
+                        {this.renderProfileButton()}
                       </Grid>
-                      <Grid item xs={12} sm='auto'>
-                        <Button className={classes.NaviBtn} component={Link} to={path.accounts}>
-                          Accounts
-                        </Button>
-                      </Grid>
-                      <Grid item xs={12} sm='auto'>
-                        <Button className={classes.NaviBtn} component={Link} to={path.wallet}>
-                          Chainsfr Wallet
-                        </Button>
-                      </Grid>
-                      <Grid item xs={12} sm='auto'>
-                        <Button
-                          aria-owns={anchorEl ? 'simple-menu' : undefined}
-                          aria-haspopup='true'
-                          onClick={this.handleToggle}
-                          id='avatarBtn'
-                          style={{ textTransform: 'none' }}
-                          disabled={disabled}
-                        >
-                          {profile && profile.profileObj && profile.profileObj.imageUrl ? (
-                            <Avatar
-                              alt=''
-                              src={profile.profileObj.imageUrl}
-                              className={classes.avatar}
-                            />
-                          ) : (
-                            <AccountCircle className={classes.userIcon} id='accountCircle' />
-                          )}
-                          <Typography>{profile.profileObj.name}</Typography>
-                        </Button>
-                        <Menu
-                          id='simple-menu'
-                          anchorEl={anchorEl}
-                          getContentAnchorEl={null}
-                          open={Boolean(anchorEl)}
-                          onClose={this.handleClose()}
-                          anchorOrigin={{
-                            vertical: 'bottom',
-                            horizontal: 'right'
-                          }}
-                          transformOrigin={{
-                            vertical: 'top',
-                            horizontal: 'right'
-                          }}
-                        >
-                          <Container className={classes.menuContainer}>
-                            {profile && profile.profileObj && profile.profileObj.imageUrl ? (
-                              <Avatar
-                                alt=''
-                                src={profile.profileObj.imageUrl}
-                                className={classes.avatar}
-                              />
-                            ) : (
-                              <AccountCircle className={classes.userIcon} id='accountCircle' />
-                            )}
-                            <Typography className={classes.menuItemUserName}>
-                              {profile.profileObj.name}
-                            </Typography>
-                            <Typography className={classes.menuItemEmail}>
-                              {profile.profileObj.email}
-                            </Typography>
-                            <Divider />
-                            <Button
-                              onClick={this.handleClose('logout')}
-                              id='logout'
-                              className={classes.logoutBtn}
-                            >
-                              <ExitIcon className={classes.logoutIcon} id='exitIcon' />
-                              <Typography>Logout</Typography>
-                            </Button>
-                          </Container>
-                        </Menu>
+                    </>
+                  ) : (
+                    <Grid item>
+                      <Grid container alignItems='center'>
+                        <Grid item xs={12} sm='auto'>
+                          <Button className={classes.NaviBtn} component={Link} to={path.home}>
+                            Home
+                          </Button>
+                        </Grid>
+                        <Grid item xs={12} sm='auto'>
+                          <Button className={classes.NaviBtn} component={Link} to={path.recipients}>
+                            Recipients
+                          </Button>
+                        </Grid>
+                        <Grid item xs={12} sm='auto'>
+                          <Button className={classes.NaviBtn} component={Link} to={path.accounts}>
+                            Accounts
+                          </Button>
+                        </Grid>
+                        <Grid item xs={12} sm='auto'>
+                          <Button className={classes.NaviBtn} component={Link} to={path.wallet}>
+                            Chainsfr Wallet
+                          </Button>
+                        </Grid>
+                        <Grid item xs={12} sm='auto'>
+                          {this.renderProfileButton()}
+                        </Grid>
                       </Grid>
                     </Grid>
-                  </Grid>
-                )}
+                  ))}
               </Grid>
             </Grid>
           </Grid>

--- a/src/components/ReceiveComponent.jsx
+++ b/src/components/ReceiveComponent.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 
 import { withStyles } from '@material-ui/core/styles'
-import Stepper from './Stepper'
 import Grid from '@material-ui/core/Grid'
 import ReceiveForm from '../containers/ReceiveFormContainer'
 import ReceiveReview from '../containers/ReceiveReviewContainer'
@@ -15,9 +14,6 @@ class ReceiveComponent extends React.Component {
       <Grid container direction='column' alignItems='center'>
         <Grid item className={classes.sectionContainer}>
           <Grid container direction='column'>
-            <Grid item>
-              <Stepper actionType='receive' step={step} />
-            </Grid>
             <Grid item>
               <Grid container direction='column' alignItems='center'>
                 <Grid item className={classes.subComponent}>

--- a/src/components/ReceiveFormComponent.jsx
+++ b/src/components/ReceiveFormComponent.jsx
@@ -242,7 +242,7 @@ class ReceiveFormComponent extends Component {
 
   onAccountChange = event => {
     const { transferForm, updateTransferForm } = this.props
-    updateTransferForm(update(transferForm, { accountSelection: { $set: event.target.value } }))
+    updateTransferForm(update(transferForm, { accountId: { $set: event.target.value } }))
   }
 
   renderUnableToAccept () {
@@ -307,6 +307,7 @@ class ReceiveFormComponent extends Component {
               <AccountDropdownContainer
                 onChange={this.onAccountChange}
                 filterCriteria={accountData => accountData.cryptoType === transfer.cryptoType}
+                accountId={accountSelection}
               />
             </Grid>
             <Grid item>

--- a/src/components/ReviewComponent.jsx
+++ b/src/components/ReviewComponent.jsx
@@ -4,11 +4,7 @@ import Grid from '@material-ui/core/Grid'
 import Button from '@material-ui/core/Button'
 import { withStyles } from '@material-ui/core/styles'
 import Typography from '@material-ui/core/Typography'
-import Paper from '@material-ui/core/Paper'
 import { getCryptoSymbol, getTxFeesCryptoType } from '../tokens'
-import LinearProgress from '@material-ui/core/LinearProgress'
-import { getWalletTitle } from '../wallet'
-import MetamaskPendingIcon from '../images/metamask_pending.png'
 import Divider from '@material-ui/core/Divider'
 
 type Props = {
@@ -27,100 +23,6 @@ type Props = {
   }
 }
 
-const BASE_WALLET_INSTRUCTION = {
-  ledger:
-    'Please keep your Ledger connected and carefully verify all transaction details on your device. ' +
-    'Press the right button to confirm and sign the transaction if everything is correct. ' +
-    'The transaction is then signed and sent to the network for confirmation.',
-  metamask: 'Please confirm transaction in the Metamask popup window.',
-  drive: 'Please wait while we are broadcasting your transaction to the network.',
-  metamaskWalletConnect: 'Please confirm transaction in the MetaMask Mobile on your phone',
-  walletLink: 'Please confirm transaction in the Mobile wallet on your phone',
-  referralWallet: 'Please wait while we are broadcasting your transaction to the network.'
-}
-
-const BASE_CRYPTO_INSTRUCTION = {
-  dai:
-    'Two consecutive transactions will be sent: The first one prepays the transaction fees for receiving or cancellation.' +
-    'The second one sends DAI tokens.'
-}
-
-const WALLET_INSTRUCTION = {
-  ledger: {
-    bitcoin: BASE_WALLET_INSTRUCTION.ledger,
-    ethereum: BASE_WALLET_INSTRUCTION.ledger,
-    dai: (
-      <div>
-        {BASE_WALLET_INSTRUCTION.ledger}
-        <br /> <br />
-        {BASE_CRYPTO_INSTRUCTION.dai}
-      </div>
-    )
-  },
-  metamask: {
-    ethereum: (
-      <div>
-        {BASE_WALLET_INSTRUCTION.metamask}
-        <br /> <br />
-        Look for <img src={MetamaskPendingIcon} alt='metamask pending icon' />
-        on the right side of the address bar if the popup is not shown.
-      </div>
-    ),
-    dai: (
-      <div>
-        {BASE_WALLET_INSTRUCTION.metamask}
-        <br /> <br />
-        {BASE_CRYPTO_INSTRUCTION.dai}
-        <br /> <br />
-        Look for <img src={MetamaskPendingIcon} alt='metamask pending icon' />
-        on the right side of the address bar if the popup is not shown.
-      </div>
-    )
-  },
-  drive: {
-    bitcoin: BASE_WALLET_INSTRUCTION.drive,
-    ethereum: BASE_WALLET_INSTRUCTION.drive,
-    dai: BASE_WALLET_INSTRUCTION.drive,
-    libra: BASE_WALLET_INSTRUCTION.drive
-  },
-  metamaskWalletConnect: {
-    ethereum: <div>{BASE_WALLET_INSTRUCTION.metamaskWalletConnect}</div>,
-    dai: (
-      <div>
-        {BASE_WALLET_INSTRUCTION.metamaskWalletConnect}
-        <br /> <br />
-        {BASE_CRYPTO_INSTRUCTION.dai}
-      </div>
-    )
-  },
-  trustWalletConnect: {
-    ethereum: <div>{BASE_WALLET_INSTRUCTION.metamaskWalletConnect}</div>,
-    dai: (
-      <div>
-        {BASE_WALLET_INSTRUCTION.metamaskWalletConnect}
-        <br /> <br />
-        {BASE_CRYPTO_INSTRUCTION.dai}
-      </div>
-    )
-  },
-  coinomiWalletConnect: {
-    ethereum: <div>{BASE_WALLET_INSTRUCTION.metamaskWalletConnect}</div>,
-    dai: (
-      <div>
-        {BASE_WALLET_INSTRUCTION.metamaskWalletConnect}
-        <br /> <br />
-        {BASE_CRYPTO_INSTRUCTION.dai}
-      </div>
-    )
-  },
-  coinbaseWalletLink: {
-    ethereum: <div>{BASE_WALLET_INSTRUCTION.walletLink}</div>
-  },
-  referralWallet: {
-    ethereum: <div>{BASE_WALLET_INSTRUCTION.referralWallet}</div>
-  }
-}
-
 class ReviewComponent extends Component<Props> {
   render () {
     const { classes, transferForm, actionsPending, txFee, currencyAmount } = this.props
@@ -134,7 +36,7 @@ class ReviewComponent extends Component<Props> {
       sendMessage,
       accountId
     } = transferForm
-    const { cryptoType, walletType } = accountId
+    const { cryptoType } = accountId
     return (
       <Grid container direction='column'>
         <Grid item>
@@ -235,27 +137,6 @@ class ReviewComponent extends Component<Props> {
             <Grid item>
               <Divider />
             </Grid>
-            {actionsPending.submitTx && (
-              <Grid item>
-                <Paper style={{ padding: '20px', marginTop: '30px' }}>
-                  <Grid container direction='column'>
-                    <Grid item>
-                      <Typography variant='h6'>
-                        {getWalletTitle(walletType)} Transfer Instructions
-                      </Typography>
-                    </Grid>
-                    <Grid>
-                      <Typography variant='caption'>
-                        {WALLET_INSTRUCTION[walletType][cryptoType]}
-                      </Typography>
-                    </Grid>
-                    <Grid>
-                      <LinearProgress className={classes.linearProgress} />
-                    </Grid>
-                  </Grid>
-                </Paper>
-              </Grid>
-            )}
           </Grid>
         </Grid>
         <Grid item className={classes.btnSection}>

--- a/src/components/SendToAnotherAccountModal.jsx
+++ b/src/components/SendToAnotherAccountModal.jsx
@@ -1,0 +1,421 @@
+import React, { Component } from 'react'
+import { withStyles } from '@material-ui/core/styles'
+
+import Button from '@material-ui/core/Button'
+import Divider from '@material-ui/core/Divider'
+import Dialog from '@material-ui/core/Dialog'
+import CheckCircleIcon from '@material-ui/icons/CheckCircleRounded'
+
+import Grid from '@material-ui/core/Grid'
+import Typography from '@material-ui/core/Typography'
+import LinearProgress from '@material-ui/core/LinearProgress'
+import TextField from '@material-ui/core/TextField'
+import TransferForm from '../containers/FormContainer'
+import { getCryptoSymbol, getTxFeesCryptoType } from '../tokens'
+
+class SendToAnotherAccountModal extends Component {
+  renderReview = () => {
+    const {
+      transferForm,
+      accountSelection,
+      txFee,
+      currencyAmount,
+      errors,
+      classes,
+      actionsPending,
+      handleConfirm,
+      password,
+      handlePasswordChange
+    } = this.props
+    const { transferAmount, destination } = transferForm
+    const { cryptoType } = accountSelection
+    return (
+      <Grid container direction='column'>
+        <Grid item>
+          <Grid container direction='column' spacing={2}>
+            <Grid item>
+              <Grid container direction='row' align='center'>
+                <Grid item xs={6}>
+                  <Grid container direction='column' alignItems='flex-start'>
+                    <Typography variant='caption'>From</Typography>
+                    <Typography variant='body2' id='senderName'>
+                      Chainsfr Wallet
+                    </Typography>
+                    <Typography variant='caption' id='senderName'>
+                      {cryptoType === 'bitcoin'
+                        ? `${accountSelection.hdWalletVariables.xpub.slice(
+                            0,
+                            12
+                          )}...${accountSelection.hdWalletVariables.xpub.slice(-20)}`
+                        : accountSelection.address}
+                    </Typography>
+                  </Grid>
+                </Grid>
+                <Grid item xs={6}>
+                  <Grid container direction='column' alignItems='flex-start'>
+                    <Typography variant='caption'>To</Typography>
+                    <Typography variant='body2' id='receiverName'>
+                      {destination.name}
+                    </Typography>
+                    <Typography variant='caption' id='receiverName'>
+                      {destination.address}
+                    </Typography>
+                  </Grid>
+                </Grid>
+              </Grid>
+            </Grid>
+            <Grid item>
+              <Divider />
+            </Grid>
+            <Grid item>
+              <Grid container direction='column' alignItems='flex-start'>
+                <Grid item>
+                  <Typography variant='caption'>Amount</Typography>
+                </Grid>
+                <Grid item>
+                  <Grid container direction='row' alignItems='center'>
+                    <Typography variant='body2'>
+                      {transferAmount} {getCryptoSymbol(cryptoType)}
+                    </Typography>
+                    <Typography style={{ marginLeft: '10px' }} variant='caption'>
+                      ( ≈ {currencyAmount.transferAmount} )
+                    </Typography>
+                  </Grid>
+                </Grid>
+              </Grid>
+            </Grid>
+            <Grid item>
+              <Divider />
+            </Grid>
+            <Grid item>
+              <Grid container direction='column' alignItems='flex-start'>
+                <Grid item>
+                  <Typography variant='caption'>Transaction Fee</Typography>
+                </Grid>
+                <Grid item>
+                  <Grid container direction='row' alignItems='center'>
+                    <Typography variant='body2'>
+                      {txFee.costInStandardUnit} {getCryptoSymbol(getTxFeesCryptoType(cryptoType))}
+                    </Typography>
+                    <Typography style={{ marginLeft: '10px' }} variant='caption'>
+                      ( ≈ {currencyAmount.txFee} )
+                    </Typography>
+                  </Grid>
+                </Grid>
+              </Grid>
+            </Grid>
+            <Grid item>
+              <Divider />
+            </Grid>
+            <Grid item>
+              <Typography variant='body2' align='left'>
+                Unlock your Chainsfr Wallet to transfer
+              </Typography>
+            </Grid>
+            <Grid item>
+              <TextField
+                fullWidth
+                autoFocus
+                id='password'
+                label='Chainsfr Wallet Password'
+                margin='normal'
+                variant='outlined'
+                error={!!errors.checkWalletConnection}
+                helperText={errors.checkWalletConnection ? 'Incorrect password' : ''}
+                onChange={event => {
+                  handlePasswordChange(event.target.value)
+                }}
+                value={password}
+                type='password'
+                onKeyPress={ev => {
+                  if (ev.key === 'Enter') {
+                    handleConfirm(password)
+                  }
+                }}
+              />
+            </Grid>
+            {(actionsPending.checkWalletConnection ||
+              actionsPending.verifyAccount ||
+              actionsPending.directTransfer) && (
+              <Grid item>
+                <Grid
+                  container
+                  direction='column'
+                  className={classes.linearProgressContainer}
+                  spacing={2}
+                >
+                  <Grid item>
+                    <Typography variant='body2'>Checking password...</Typography>
+                  </Grid>
+                  <Grid item>
+                    <LinearProgress className={classes.linearProgress} />
+                  </Grid>
+                </Grid>
+              </Grid>
+            )}
+          </Grid>
+        </Grid>
+      </Grid>
+    )
+  }
+
+  renderReceipt = () => {
+    const { transferForm, accountSelection, txFee, currencyAmount, receipt, sendTime } = this.props
+    const { transferAmount, destination } = transferForm
+    const { cryptoType } = accountSelection
+    return (
+      <Grid container direction='column'>
+        <Grid item>
+          <Grid container direction='column' spacing={2}>
+            <Grid item>
+              <Typography variant='h3'>Review and Confirm</Typography>
+            </Grid>
+            <Grid item>
+              <Grid container direction='row' align='center'>
+                <Grid item xs={6}>
+                  <Grid container direction='column' alignItems='flex-start'>
+                    <Typography variant='caption'>From</Typography>
+                    <Typography variant='body2' id='senderName'>
+                      Chainsfr Wallet
+                    </Typography>
+                    <Typography variant='caption'>
+                      {cryptoType === 'bitcoin'
+                        ? `${accountSelection.hdWalletVariables.xpub.slice(
+                            0,
+                            16
+                          )}...${accountSelection.hdWalletVariables.xpub.slice(-24)}`
+                        : accountSelection.address}
+                    </Typography>
+                  </Grid>
+                </Grid>
+                <Grid item xs={6}>
+                  <Grid container direction='column' alignItems='flex-start'>
+                    <Typography variant='caption'>To</Typography>
+                    <Typography variant='body2' id='receiverName'>
+                      {destination.name}
+                    </Typography>
+                    <Typography variant='caption'>{destination.address}</Typography>
+                  </Grid>
+                </Grid>
+              </Grid>
+            </Grid>
+            <Grid item>
+              <Divider />
+            </Grid>
+            <Grid item>
+              <Grid container direction='column' alignItems='flex-start'>
+                <Grid item>
+                  <Typography variant='caption'>Amount</Typography>
+                </Grid>
+                <Grid item>
+                  <Grid container direction='row' alignItems='center'>
+                    <Typography variant='body2'>
+                      {transferAmount} {getCryptoSymbol(cryptoType)}
+                    </Typography>
+                    <Typography style={{ marginLeft: '10px' }} variant='caption'>
+                      ( ≈ {currencyAmount.transferAmount} )
+                    </Typography>
+                  </Grid>
+                </Grid>
+              </Grid>
+            </Grid>
+            <Grid item>
+              <Divider />
+            </Grid>
+            <Grid item>
+              <Grid container direction='column' alignItems='flex-start'>
+                <Grid item>
+                  <Typography variant='caption'>Transaction Fee</Typography>
+                </Grid>
+                <Grid item>
+                  <Grid container direction='row' alignItems='center'>
+                    <Typography variant='body2'>
+                      {txFee.costInStandardUnit} {getCryptoSymbol(getTxFeesCryptoType(cryptoType))}
+                    </Typography>
+                    <Typography style={{ marginLeft: '10px' }} variant='caption'>
+                      ( ≈ {currencyAmount.txFee} )
+                    </Typography>
+                  </Grid>
+                </Grid>
+              </Grid>
+            </Grid>
+            <Grid item>
+              <Divider />
+            </Grid>
+            <Grid item>
+              <Typography variant='caption'>Sent on Time: {sendTime}</Typography>
+            </Grid>
+            <Grid item>
+              <Typography variant='caption'>Transfer Hash: {receipt.txHash}</Typography>
+            </Grid>
+          </Grid>
+        </Grid>
+      </Grid>
+    )
+  }
+
+  renderDialogContent = () => {
+    const { step } = this.props
+    let content
+    switch (step) {
+      case 0:
+        content = <TransferForm form='direct_transfer' />
+        break
+      case 1:
+        content = this.renderReview()
+        break
+      case 2:
+        content = this.renderReceipt()
+        break
+      default:
+        content = null
+    }
+    return <div>{content}</div>
+  }
+
+  renderDialogActions = () => {
+    const { password, step, back, next, errors } = this.props
+    let buttons
+    switch (step) {
+      case 0:
+        buttons = (
+          <>
+            <Button
+              onClick={() => {
+                back()
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant='contained'
+              color='primary'
+              onClick={() => {
+                next()
+              }}
+              style={{ marginLeft: '40px' }}
+            >
+              Continue
+            </Button>
+          </>
+        )
+        break
+      case 1:
+        buttons = (
+          <>
+            <Button
+              onClick={() => {
+                back()
+              }}
+            >
+              Back to Previous
+            </Button>
+            <Button
+              variant='contained'
+              color='primary'
+              onClick={() => {
+                next(password)
+              }}
+              style={{ marginLeft: '40px' }}
+              disabled={
+                password.length === 0 || !!errors.checkWalletConnection || !!errors.directTransfer
+              }
+            >
+              Confirm and Transfer
+            </Button>
+          </>
+        )
+        break
+      case 2:
+      default:
+        buttons = (
+          <Button
+            variant='contained'
+            color='primary'
+            onClick={() => {
+              next()
+            }}
+            style={{ marginLeft: '40px' }}
+          >
+            Close
+          </Button>
+        )
+        break
+    }
+    return buttons
+  }
+
+  renderDialogTitle = () => {
+    const { step, classes } = this.props
+    switch (step) {
+      case 0:
+        return <Typography variant='h2'>Transfer to Another Account</Typography>
+      case 1:
+        return <Typography variant='h2'>Review and Confirm</Typography>
+      case 2:
+        return (
+          <Grid container direction='column' justify='center' align='center'>
+            <CheckCircleIcon className={classes.checkCircleIcon} />
+            <Typography variant='h3'>Transfer Completed</Typography>
+          </Grid>
+        )
+      default:
+        return null
+    }
+  }
+
+  render () {
+    const { open, handleClose, classes } = this.props
+    return (
+      <Dialog
+        open={open}
+        onClose={() => {
+          handleClose()
+        }}
+        scroll='body'
+        classes={{ paperScrollBody: classes.paperScrollBody }}
+      >
+        <div className={classes.dialogTitle}>{this.renderDialogTitle()}</div>
+        <div>{this.renderDialogContent()}</div>
+        <div className={classes.actionSection}>{this.renderDialogActions()}</div>
+      </Dialog>
+    )
+  }
+}
+
+const styles = theme => ({
+  closeButton: {
+    position: 'absolute',
+    right: theme.spacing(1),
+    top: theme.spacing(1),
+    color: theme.palette.grey[500]
+  },
+  dialogTitle: {
+    marginBottom: '60px'
+  },
+  linearProgressContainer: {
+    backgroundColor: 'rgba(66,133,244,0.05)',
+    borderRadius: '4px',
+    padding: '10px 20px 10px 20px',
+    marginTop: '30px'
+  },
+  checkCircleIcon: {
+    color: '#43B384',
+    fontSize: '48px',
+    marginBottom: '14px',
+    marginTop: '15px'
+  },
+  paperScrollBody: {
+    padding: '60px',
+    width: '600px'
+  },
+  actionSection: {
+    display: 'flex',
+    direction: 'row',
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+    marginTop: '60px'
+  }
+})
+
+export default withStyles(styles)(SendToAnotherAccountModal)

--- a/src/components/Stepper.jsx
+++ b/src/components/Stepper.jsx
@@ -7,7 +7,7 @@ import StepLabel from '@material-ui/core/StepLabel'
 
 const stepsByActionType = {
   receive: ['Security Answer', 'Review', 'Receipt'],
-  transfer: ['Transfer Form', 'Review', 'Wallet Authentication', 'Receipt']
+  transfer: ['Set up', 'Review', 'Authorize']
 }
 
 type Props = {

--- a/src/components/TransferComponent.jsx
+++ b/src/components/TransferComponent.jsx
@@ -4,7 +4,7 @@ import React from 'react'
 import { withStyles } from '@material-ui/core/styles'
 import Stepper from './Stepper'
 import Grid from '@material-ui/core/Grid'
-import TransferForm from '../containers/TransferFormContainer'
+import TransferForm from '../containers/FormContainer'
 import WalletAuthorization from '../containers/WalletAuthorizationContainer'
 import Review from '../containers/ReviewContainer'
 import Receipt from '../containers/ReceiptContainer'
@@ -38,6 +38,7 @@ class TransferComponent extends React.Component<Props> {
                       cryptoTypePrefilled={urlParams && urlParams.cryptoType}
                       destinationPrefilled={urlParams && (urlParams.destination || '')}
                       receiverNamePrefilled={urlParams && (urlParams.receiverName || '')}
+                      form='email_transfer'
                     />
                   </Grid>
                 )}

--- a/src/components/TransferComponent.jsx
+++ b/src/components/TransferComponent.jsx
@@ -2,7 +2,6 @@
 import React from 'react'
 
 import { withStyles } from '@material-ui/core/styles'
-import Stepper from './Stepper'
 import Grid from '@material-ui/core/Grid'
 import TransferForm from '../containers/FormContainer'
 import WalletAuthorization from '../containers/WalletAuthorizationContainer'
@@ -25,9 +24,6 @@ class TransferComponent extends React.Component<Props> {
       <Grid container direction='column' alignItems='center'>
         <Grid item className={classes.sectionContainer}>
           <Grid container direction='column' alignItems='stretch'>
-            <Grid item>
-              <Stepper actionType='transfer' step={step} />
-            </Grid>
             <Grid item>
               <Grid container direction='column' alignItems='center'>
                 {step === 0 && (

--- a/src/components/WalletAuthorizationComponent.jsx
+++ b/src/components/WalletAuthorizationComponent.jsx
@@ -268,7 +268,7 @@ export default class WalletAuthorizationComponent extends Component<Props, State
     )
   }
 
-  render() {
+  render () {
     const { accountSelection } = this.props
 
     return (

--- a/src/components/WalletComponent.jsx
+++ b/src/components/WalletComponent.jsx
@@ -14,31 +14,18 @@ import CircularProgress from '@material-ui/core/CircularProgress'
 import { getCryptoSymbol } from '../tokens'
 import { UserRecentTransactions } from './LandingPageComponent.jsx'
 import { accountStatus } from '../types/account.flow'
-
-// function SendToAnotherAccount (props) {
-//   const { accounts } = props
-//   const [amount, setAmount] = useState(null)
-//   const [memo, setMemo] = useState(null)
-
-//   function validateAmount (cryptoType, balance, amount) {
-//     const decimals = getCryptoDecimals(cryptoType)
-//     if (
-//       !validator.isFloat(amount, { min: 0.001, max: utils.toHumanReadableUnit(balance, decimals) })
-//     ) {
-//       if (amount === '-' || parseFloat(amount) < 0.001) {
-//         return 'The amount must be greater than 0.001'
-//       } else {
-//         return `Exceed your balance of ${utils.toHumanReadableUnit(balance, decimals)}`
-//       }
-//     }
-//   }
-
-//   return
-// }
+import SendToAnotherAccountModal from '../containers/SendToAnotherAccountModalContainer'
 
 class WalletComponent extends Component {
   state = {
-    anchorEl: null
+    anchorEl: null,
+    sendToAnotherAccountModal: false
+  }
+
+  handleModalClose = () => {
+    this.setState({
+      sendToAnotherAccountModal: false
+    })
   }
 
   renderChainsfrWalletSection = () => {
@@ -84,7 +71,11 @@ class WalletComponent extends Component {
                         horizontal: 'left'
                       }}
                     >
-                      <MenuItem>
+                      <MenuItem
+                        onClick={() => {
+                          this.setState({ sendToAnotherAccountModal: true, anchorEl: null })
+                        }}
+                      >
                         <ListItemText primary='Send to my accounts' />
                       </MenuItem>
                       <MenuItem>
@@ -100,8 +91,8 @@ class WalletComponent extends Component {
             <Grid container direction='row' alignItems='center' justify='center' spacing={2}>
               {cloudWalletAccounts.map((account, index) => {
                 return (
-                  <Grid item>
-                    <Card className={classes.balanceCard} key={index}>
+                  <Grid item key={index}>
+                    <Card className={classes.balanceCard}>
                       <Grid container alignItems='center' justify='center' direction='column'>
                         <Grid item>
                           {account.status !== accountStatus.syncing ? (
@@ -129,7 +120,7 @@ class WalletComponent extends Component {
 
   render () {
     const { actionsPending, transferHistory, loadMoreTransferHistory } = this.props
-
+    const { sendToAnotherAccountModal } = this.state
     return (
       <div>
         {this.renderChainsfrWalletSection()}
@@ -138,6 +129,14 @@ class WalletComponent extends Component {
           transferHistory={transferHistory}
           loadMoreTransferHistory={loadMoreTransferHistory}
         />
+        {sendToAnotherAccountModal && (
+          <SendToAnotherAccountModal
+            handleClose={() => {
+              this.handleModalClose()
+            }}
+            open={sendToAnotherAccountModal}
+          />
+        )}
       </div>
     )
   }

--- a/src/containers/AccountDropdownContainer.jsx
+++ b/src/containers/AccountDropdownContainer.jsx
@@ -13,6 +13,7 @@ type Props = {
     cryptoType: string,
     address: string
   },
+  inputLabel: ?string,
   cryptoPrice: { [string]: Number },
   currency: string,
   onChange: Function,
@@ -53,7 +54,15 @@ class AccountDropdownContainer extends Component<Props, State> {
   }
 
   render () {
-    const { cryptoAccounts, actionsPending, cryptoPrice, currency, error, accountId } = this.props
+    const {
+      cryptoAccounts,
+      actionsPending,
+      cryptoPrice,
+      currency,
+      error,
+      accountId,
+      inputLabel
+    } = this.props
     const { openAddAccountModal } = this.state
     let { filterCriteria } = this.props
     if (!filterCriteria) {
@@ -78,6 +87,7 @@ class AccountDropdownContainer extends Component<Props, State> {
           addAccount={this.toggleAddAccountModal}
           pending={actionsPending.getCryptoAccounts}
           error={error}
+          inputLabel={inputLabel ? inputLabel : 'Select Account'}
         />
         <AddAccountModal open={openAddAccountModal} handleClose={this.toggleAddAccountModal} />
       </>

--- a/src/containers/AccountsManagementContainer.jsx
+++ b/src/containers/AccountsManagementContainer.jsx
@@ -30,6 +30,7 @@ class AccountsManagementContainer extends Component {
 
 const addCryptoAccountSelector = createLoadingSelector(['ADD_CRYPTO_ACCOUNT'])
 const removeCryptoAccountSelector = createLoadingSelector(['REMOVE_CRYPTO_ACCOUNT'])
+const getCryptoAccountsSelector = createLoadingSelector(['GET_CRYPTO_ACCOUNTS'])
 
 const errorSelector = createErrorSelector(['ADD_CRYPTO_ACCOUNT', 'REMOVE_CRYPTO_ACCOUNT'])
 
@@ -38,7 +39,8 @@ const mapStateToProps = state => {
     cryptoAccounts: state.accountReducer.cryptoAccounts,
     actionsPending: {
       addCryptoAccount: addCryptoAccountSelector(state),
-      removeCryptoAccount: removeCryptoAccountSelector(state)
+      removeCryptoAccount: removeCryptoAccountSelector(state),
+      getCryptoAccounts: getCryptoAccountsSelector(state)
     },
     error: errorSelector(state)
   }
@@ -52,7 +54,4 @@ const mapDispatchToProps = dispatch => {
   }
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(AccountsManagementContainer)
+export default connect(mapStateToProps, mapDispatchToProps)(AccountsManagementContainer)

--- a/src/containers/FormContainer.jsx
+++ b/src/containers/FormContainer.jsx
@@ -39,7 +39,7 @@ const INSUFFICIENT_FUNDS_FOR_TX_FEES = 'Insufficient funds for paying transactio
 class FormContainer extends Component<Props, State> {
   state = { openAddRecipientDialog: false }
 
-  componentDidMount() {
+  componentDidMount () {
     let {
       profile,
       transferForm,
@@ -78,7 +78,7 @@ class FormContainer extends Component<Props, State> {
     })
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate (prevProps) {
     const { transferForm, actionsPending, accountSelection } = this.props
     if (prevProps.transferForm.transferAmount !== this.props.transferForm.transferAmount) {
       // if transfer amount changed, update tx fee
@@ -149,6 +149,9 @@ class FormContainer extends Component<Props, State> {
           max: parseFloat(accountSelection.balanceInStandardUnit)
         })
       ) {
+        if (!parseFloat(value)) {
+          return null
+        }
         if (parseFloat(value) < 0.001) {
           return 'The amount must be greater than 0.001'
         } else if (parseFloat(value) > parseFloat(accountSelection.balanceInStandardUnit)) {
@@ -306,7 +309,9 @@ class FormContainer extends Component<Props, State> {
                 _account.cryptoType === event.target.value.cryptoType
             )
           },
-          destination: { $set: event.target.value }
+          destination: { $set: event.target.value },
+          transferAmount: { $set: '' },
+          transferCurrencyAmount: { $set: '' }
         })
       } else {
         const recipient = recipients.find(recipient => recipient.email === event.target.value)
@@ -319,7 +324,7 @@ class FormContainer extends Component<Props, State> {
     this.props.updateTransferForm(_transferForm)
   }
 
-  render() {
+  render () {
     const {
       cryptoPrice,
       currency,

--- a/src/containers/FormContainer.jsx
+++ b/src/containers/FormContainer.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import TransferForm from '../components/TransferFormComponent'
+import EmailTransferForm from '../components/EmailTransferFormComponent'
+import DirectTransferForm from '../components/DirectTransferFormComponent'
 import {
   updateTransferForm,
   generateSecurityAnswer,
@@ -35,10 +36,10 @@ type State = {
 }
 const INSUFFICIENT_FUNDS_FOR_TX_FEES = 'Insufficient funds for paying transaction fees'
 
-class TransferFormContainer extends Component<Props, State> {
+class FormContainer extends Component<Props, State> {
   state = { openAddRecipientDialog: false }
 
-  componentDidMount () {
+  componentDidMount() {
     let {
       profile,
       transferForm,
@@ -77,7 +78,7 @@ class TransferFormContainer extends Component<Props, State> {
     })
   }
 
-  componentDidUpdate (prevProps) {
+  componentDidUpdate(prevProps) {
     const { transferForm, actionsPending, accountSelection } = this.props
     if (prevProps.transferForm.transferAmount !== this.props.transferForm.transferAmount) {
       // if transfer amount changed, update tx fee
@@ -189,7 +190,8 @@ class TransferFormContainer extends Component<Props, State> {
         }
       }
     } else if (name === 'sender' || name === 'destination') {
-      if (!validator.isEmail(value)) {
+      // typeof valud === 'object' for direact transfer
+      if (typeof value === 'string' && !validator.isEmail(value)) {
         return 'Invalid email'
       }
     } else if (name === 'password') {
@@ -212,7 +214,14 @@ class TransferFormContainer extends Component<Props, State> {
   }
 
   handleTransferFormChange = name => event => {
-    const { transferForm, cryptoPrice, recipients, accountSelection } = this.props
+    const {
+      transferForm,
+      cryptoPrice,
+      recipients,
+      accountSelection,
+      form,
+      cryptoAccounts
+    } = this.props
 
     // helper functions for converting currency
     const toCurrencyAmount = cryptoAmount =>
@@ -288,16 +297,29 @@ class TransferFormContainer extends Component<Props, State> {
 
     if (name === 'destination' && event.target.value !== 'AddRecipient') {
       // update receiverName
-      const recipient = recipients.find(recipient => recipient.email === event.target.value)
-      if (recipient) {
-        _transferForm = update(_transferForm, { receiverName: { $set: recipient.name } })
+      if (form === 'direct_transfer') {
+        _transferForm = update(_transferForm, {
+          accountId: {
+            $set: cryptoAccounts.find(
+              _account =>
+                _account.walletType === 'drive' &&
+                _account.cryptoType === event.target.value.cryptoType
+            )
+          },
+          destination: { $set: event.target.value }
+        })
+      } else {
+        const recipient = recipients.find(recipient => recipient.email === event.target.value)
+        if (recipient) {
+          _transferForm = update(_transferForm, { receiverName: { $set: recipient.name } })
+        }
       }
     }
 
     this.props.updateTransferForm(_transferForm)
   }
 
-  render () {
+  render() {
     const {
       cryptoPrice,
       currency,
@@ -306,9 +328,12 @@ class TransferFormContainer extends Component<Props, State> {
       walletSelectionPrefilled,
       cryptoTypePrefilled,
       addressPrefilled,
-      accountSelection
+      accountSelection,
+      form,
+      transferForm
     } = this.props
     let balanceCurrencyAmount = '0'
+
     if (accountSelection) {
       balanceCurrencyAmount = utils.toCurrencyAmount(
         accountSelection.balanceInStandardUnit,
@@ -317,9 +342,20 @@ class TransferFormContainer extends Component<Props, State> {
       )
     }
 
+    if (form === 'direct_transfer') {
+      return (
+        <DirectTransferForm
+          currency={currency}
+          handleTransferFormChange={this.handleTransferFormChange}
+          accountSelection={accountSelection}
+          balanceCurrencyAmount={balanceCurrencyAmount}
+          transferForm={transferForm}
+        />
+      )
+    }
     return (
       <>
-        <TransferForm
+        <EmailTransferForm
           {...this.props}
           handleTransferFormChange={this.handleTransferFormChange}
           validate={this.validate}
@@ -368,6 +404,7 @@ const mapStateToProps = state => {
     accountSelection: state.accountReducer.cryptoAccounts.find(_account =>
       utils.accountsEqual(_account, state.formReducer.transferForm.accountId)
     ),
+    cryptoAccounts: state.accountReducer.cryptoAccounts,
     profile: state.userReducer.profile,
     txFee: state.transferReducer.txFee,
     cryptoPrice: state.cryptoPriceReducer.cryptoPrice,
@@ -382,4 +419,4 @@ const mapStateToProps = state => {
   }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(TransferFormContainer)
+export default connect(mapStateToProps, mapDispatchToProps)(FormContainer)

--- a/src/containers/NavBarContainer.jsx
+++ b/src/containers/NavBarContainer.jsx
@@ -7,7 +7,7 @@ import path from '../Paths.js'
 import moment from 'moment'
 
 class NavBarContainer extends Component {
-  backToHome=() => {
+  backToHome = () => {
     const { location, backToHome } = this.props
     if (location.pathname === path.transfer) {
       backToHome()
@@ -28,22 +28,29 @@ class NavBarContainer extends Component {
 
   componentDidMount () {
     this.checkLoginStatus()
-    setInterval(
-      () => {
-        this.checkLoginStatus()
-      },
-      1000 * 60 * 30
-    )
+    setInterval(() => {
+      this.checkLoginStatus()
+    }, 1000 * 60 * 30)
   }
 
   render () {
-    let { onLogout, profile } = this.props
+    let { onLogout, profile, location, steps } = this.props
+    let step = 0
+    if (location.pathname === path.receive) {
+      step = steps.receive
+    }
+    if (location.pathname === path.transfer) {
+      step = steps.send
+    }
     return (
       <NavBarComponent
         onLogout={onLogout}
         profile={profile}
         backToHome={this.backToHome}
-      />)
+        location={location}
+        step={step}
+      />
+    )
   }
 }
 
@@ -57,11 +64,9 @@ const mapDispatchToProps = dispatch => {
 
 const mapStateToProps = state => {
   return {
-    profile: state.userReducer.profile
+    profile: state.userReducer.profile,
+    steps: state.navigationReducer
   }
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(NavBarContainer)
+export default connect(mapStateToProps, mapDispatchToProps)(NavBarContainer)

--- a/src/containers/ReceiveFormContainer.jsx
+++ b/src/containers/ReceiveFormContainer.jsx
@@ -78,7 +78,9 @@ const mapDispatchToProps = dispatch => {
 const mapStateToProps = state => {
   return {
     transfer: state.transferReducer.transfer,
-    accountSelection: state.formReducer.transferForm.accountSelection,
+    accountSelection: state.accountReducer.cryptoAccounts.find(_account =>
+      utils.accountsEqual(_account, state.formReducer.transferForm.accountId)
+    ),
     escrowAccount: state.accountReducer.escrowAccount,
     transferForm: state.formReducer.transferForm,
     cryptoPrice: state.cryptoPriceReducer.cryptoPrice,

--- a/src/containers/ReceiveReviewContainer.jsx
+++ b/src/containers/ReceiveReviewContainer.jsx
@@ -92,7 +92,9 @@ const mapStateToProps = state => {
   return {
     transfer: state.transferReducer.transfer,
     escrowAccount: state.accountReducer.escrowAccount,
-    accountSelection: state.formReducer.transferForm.accountSelection,
+    accountSelection: state.accountReducer.cryptoAccounts.find(_account =>
+      utils.accountsEqual(_account, state.formReducer.transferForm.accountId)
+    ),
     txFee: state.transferReducer.txFee,
     cryptoPrice: state.cryptoPriceReducer.cryptoPrice,
     currency: state.cryptoPriceReducer.currency,
@@ -105,7 +107,4 @@ const mapStateToProps = state => {
   }
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(ReceiveReviewContainer)
+export default connect(mapStateToProps, mapDispatchToProps)(ReceiveReviewContainer)

--- a/src/containers/SendToAnotherAccountModalContainer.jsx
+++ b/src/containers/SendToAnotherAccountModalContainer.jsx
@@ -1,0 +1,183 @@
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+
+import { createLoadingSelector, createErrorSelector } from '../selectors'
+import SendToAnotherAccountModal from '../components/SendToAnotherAccountModal'
+import utils from '../utils'
+import { decryptCloudWalletAccount, markAccountDirty } from '../actions/accountActions.js'
+import { clearError } from '../actions/userActions'
+import { directTransfer } from '../actions/transferActions'
+import { verifyAccount, checkWalletConnection } from '../actions/walletActions'
+import moment from 'moment'
+
+class SendToAnotherAccountModalContainer extends Component {
+  state = {
+    step: 0,
+    password: ''
+  }
+
+  next = param => {
+    if (this.state.step === 1) {
+      const { accountSelection, checkWalletConnection } = this.props
+      checkWalletConnection(accountSelection, { password: param })
+    } else if (this.state.step < 2) {
+      this.setState(prevState => ({ step: prevState.step + 1 }))
+    } else {
+      this.props.handleClose()
+    }
+  }
+
+  back = () => {
+    if (this.state.step > 0) {
+      this.setState(prevState => ({ step: prevState.step - 1 }))
+    } else {
+      this.props.handleClose()
+    }
+  }
+
+  handlePasswordChange = value => {
+    const { errors, clearError } = this.props
+    if (errors.checkWalletConnection) {
+      clearError()
+    }
+    this.setState({ password: value })
+  }
+
+  handleConfirm = password => {}
+
+  componentDidUpdate (prevProps) {
+    const {
+      transferForm,
+      txFee,
+      actionsPending,
+      verifyAccount,
+      errors,
+      markAccountDirty,
+      accountSelection,
+      directTransfer
+    } = this.props
+    const { transferAmount, destination } = transferForm
+    if (
+      prevProps.actionsPending.checkWalletConnection &&
+      !actionsPending.checkWalletConnection &&
+      !errors.checkWalletConnection
+    ) {
+      verifyAccount(accountSelection)
+    } else if (
+      prevProps.actionsPending.verifyAccount &&
+      !actionsPending.verifyAccount &&
+      accountSelection.connected
+    ) {
+      // mart account dirty
+      markAccountDirty(accountSelection)
+      // submit tx
+      directTransfer({
+        fromAccount: accountSelection,
+        transferAmount: transferAmount,
+        destinationAddress: destination.address,
+        txFee: txFee
+      })
+    } else if (
+      prevProps.actionsPending.directTransfer &&
+      !actionsPending.directTransfer &&
+      !errors.directTransfer
+    ) {
+      this.setState({ step: 2 })
+    }
+  }
+
+  render () {
+    const {
+      transferForm,
+      handleClose,
+      open,
+      accountSelection,
+      txFee,
+      cryptoPrice,
+      currency,
+      decryptCloudWalletAccount,
+      actionsPending,
+      errors,
+      clearError,
+      receipt
+    } = this.props
+
+    const { step, password } = this.state
+
+    const toCurrencyAmount = cryptoAmount =>
+      utils.toCurrencyAmount(cryptoAmount, cryptoPrice[transferForm.cryptoType], currency)
+    let sendTime = ''
+    if (step === 2) sendTime = moment.unix(receipt.sendTimestamp).format('MMM Do YYYY, HH:mm:ss')
+    return (
+      <SendToAnotherAccountModal
+        open={open}
+        handleClose={handleClose}
+        transferForm={transferForm}
+        accountSelection={accountSelection}
+        txFee={txFee}
+        currencyAmount={{
+          transferAmount: transferForm && toCurrencyAmount(transferForm.transferAmount),
+          txFee: txFee && toCurrencyAmount(txFee.costInStandardUnit)
+        }}
+        decryptCloudWalletAccount={decryptCloudWalletAccount}
+        actionsPending={actionsPending}
+        errors={errors}
+        clearError={clearError}
+        handleConfirm={this.handleConfirm}
+        step={step}
+        password={password}
+        handlePasswordChange={this.handlePasswordChange}
+        next={this.next}
+        back={this.back}
+        receipt={receipt}
+        sendTime={sendTime}
+      />
+    )
+  }
+}
+
+const directTransferSelector = createLoadingSelector(['DIRECT_TRANSFER'])
+const verifyAccountSelector = createLoadingSelector(['VERIFY_ACCOUNT'])
+const checkWalletConnectionSelector = createLoadingSelector(['CHECK_WALLET_CONNECTION'])
+
+const directTransferErrorSelector = createErrorSelector(['DIRECT_TRANSFER'])
+const checkWalletConnectionErrorSelector = createErrorSelector(['CHECK_WALLET_CONNECTION'])
+const verifyAccountErrorSelector = createErrorSelector(['VERIFY_ACCOUNT'])
+
+const mapDispatchToProps = dispatch => {
+  return {
+    decryptCloudWalletAccount: (accountData, password) =>
+      dispatch(decryptCloudWalletAccount(accountData, password)),
+    clearError: () => dispatch(clearError()),
+    verifyAccount: (accountData, options) => dispatch(verifyAccount(accountData, options)),
+    checkWalletConnection: (accountData, options) =>
+      dispatch(checkWalletConnection(accountData, options)),
+    directTransfer: txRequest => dispatch(directTransfer(txRequest)),
+    markAccountDirty: accountData => dispatch(markAccountDirty(accountData))
+  }
+}
+
+const mapStateToProps = state => {
+  return {
+    transferForm: state.formReducer.transferForm,
+    accountSelection: state.accountReducer.cryptoAccounts.find(_account =>
+      utils.accountsEqual(_account, state.formReducer.transferForm.accountId)
+    ),
+    txFee: state.transferReducer.txFee,
+    cryptoPrice: state.cryptoPriceReducer.cryptoPrice,
+    currency: state.cryptoPriceReducer.currency,
+    actionsPending: {
+      checkWalletConnection: checkWalletConnectionSelector(state),
+      verifyAccount: verifyAccountSelector(state),
+      directTransfer: directTransferSelector(state)
+    },
+    errors: {
+      checkWalletConnection: checkWalletConnectionErrorSelector(state),
+      verifyAccount: verifyAccountErrorSelector(state),
+      directTransfer: directTransferErrorSelector(state)
+    },
+    receipt: state.transferReducer.receipt
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(SendToAnotherAccountModalContainer)

--- a/src/reducers/accountReducer.js
+++ b/src/reducers/accountReducer.js
@@ -79,6 +79,7 @@ export default function (state = initState, action) {
     case 'SYNC_WITH_NETWORK_FULFILLED':
     case 'CHECK_WALLET_CONNECTION_FULFILLED':
     case 'VERIFY_ACCOUNT_FULFILLED':
+    case 'CLEAR_ACCOUNT_PRIVATE_KEY':
       return updateCryptoAccount(state, action.payload)
     case 'SYNC_WITH_NETWORK_PENDING':
       return updateCryptoAccount(state, action.meta)

--- a/src/reducers/accountReducer.js
+++ b/src/reducers/accountReducer.js
@@ -77,6 +77,7 @@ export default function (state = initState, action) {
       return updateCryptoAccount(state, action.payload, true, false)
     case 'MARK_ACCOUNT_DIRTY':
     case 'SYNC_WITH_NETWORK_FULFILLED':
+    case 'CHECK_WALLET_CONNECTION_FULFILLED':
     case 'VERIFY_ACCOUNT_FULFILLED':
       return updateCryptoAccount(state, action.payload)
     case 'SYNC_WITH_NETWORK_PENDING':

--- a/src/reducers/formReducer.js
+++ b/src/reducers/formReducer.js
@@ -9,7 +9,12 @@ import update from 'immutability-helper'
     cryptoType: string,
     walletType: string,
     address: string
-  }
+  },
+  destination: string | Object<{
+    walletType: string,
+    cryptoType: string,
+    address: string
+  }>,
 */
 
 const initialState = {

--- a/src/types/account.flow.js
+++ b/src/types/account.flow.js
@@ -101,6 +101,7 @@ export interface IAccount<AccountData> {
   accountData: AccountData;
 
   constructor(account?: AccountData): void;
+  clearPrivateKey(): void;
   getAccountData(): AccountData;
   encryptAccount(password: string): Promise<void>;
   decryptAccount(password: string): Promise<void>;

--- a/src/wallets/drive.js
+++ b/src/wallets/drive.js
@@ -261,7 +261,7 @@ export default class DriveWallet implements IWallet<AccountData> {
       if (options.directTransfer) {
         // direct transfer to another address
         txObj = {
-          from: account.address,
+          from: accountData.address,
           to: to,
           value: value
         }


### PR DESCRIPTION
- Resolve #956 Refractor TransferFormContainer/Component
- Resolve #957 Fix a bug when user's cryptoAccounts are being loaded but shows no crypto
accounts in accountManagementComponent
- Resolve #958 Add Chainsfr Wallet direct transfer
- Resolve #965 Add inputLabel props to AccountDropDownComponent
- Resolve #960 Add clear account private key function …
- Resolve #964 Add sendToAnotherAccountModal
- Resolve #966 Remove wallet connect instruction in Review Component
- Resolve #962 Move stepper to navbar
- Resolve #967 Update receive components to use accountId to find accoutSelection